### PR TITLE
Convert to Gulp-based build system

### DIFF
--- a/actioncable/.gitignore
+++ b/actioncable/.gitignore
@@ -1,3 +1,4 @@
 /dist
 /lib/assets/compiled
+/node_modules
 /tmp

--- a/actioncable/Gulpfile.coffee
+++ b/actioncable/Gulpfile.coffee
@@ -1,0 +1,21 @@
+gulp      = require('gulp')
+del       = require('del')
+include   = require('gulp-include')
+coffee    = require('gulp-coffee')
+uglify    = require('gulp-uglify')
+rename    = require('gulp-rename')
+
+gulp.task 'clean', ->
+  del(['dist/**/*'])
+
+gulp.task 'coffee', ['clean'], ->
+  gulp.src('index.coffee')
+    .pipe(include())
+    .pipe(coffee(bare: true))
+    .pipe(uglify())
+    .pipe(rename('actioncable.js'))
+    .pipe(gulp.dest('dist'))
+
+gulp.task 'default', [
+  'coffee'
+]

--- a/actioncable/README.md
+++ b/actioncable/README.md
@@ -460,6 +460,59 @@ with all the popular application servers -- Unicorn, Puma and Passenger.
 Action Cable does not work with WEBrick, because WEBrick does not support the
 Rack socket hijacking API.
 
+## npm usage
+
+Rails also publishes the client-side ActionCable as an officially supported npm 
+module, intended for usage in standalone frontends that communicate with a Rails
+API. 
+
+### Installation
+
+```
+npm install actioncable --save
+```
+
+### Usage
+
+```coffeescript
+ActionCable = require('actioncable')
+
+cable = ActionCable.createConsumer('wss://RAILS-API-PATH.com/cable')
+cable.subscriptions.create { channel: 'AppearanceChannel' },
+  # Called when the subscription is ready for use on the server
+  connected: ->
+    @install()
+    @appear()
+
+  # Called when the WebSocket connection is closed
+  disconnected: ->
+    @uninstall()
+
+  # Called when the subscription is rejected by the server
+  rejected: ->
+    @uninstall()
+
+  appear: ->
+    # Calls `AppearanceChannel#appear(data)` on the server
+    @perform("appear", appearing_on: $("main").data("appearing-on"))
+
+  away: ->
+    # Calls `AppearanceChannel#away` on the server
+    @perform("away")
+```
+
+When using ActionCable with a standalone frontend, you must take care to 
+allow connections from the request origin if it's different from the API
+host:
+
+```ruby
+# config/environments/production.rb 
+
+Rails.application.configure do
+  config.action_cable.allowed_request_origins = ['https://FRONTEND-HOST.com']
+end
+```
+
 ## License
 
 Action Cable is released under the MIT license:

--- a/actioncable/Rakefile
+++ b/actioncable/Rakefile
@@ -29,7 +29,7 @@ end
 
 namespace :assets do
   root_path = Pathname.new(dir)
-  destination_paths = [ root_path.join("lib/assets/compiled"), root_path.join("dist") ]
+  destination_path = root_path.join("lib/assets/compiled")
 
   desc "Compile dist/action_cable.js"
   task :compile do
@@ -50,13 +50,11 @@ namespace :assets do
     manifest = Sprockets::Manifest.new(environment.index, compile_path)
     manifest.compile(precompile_list)
 
-    destination_paths.each { |path| path.rmtree if path.exist? }
+    destination_path.rmtree if destination_path.exist?
 
     manifest.assets.each do |path, fingerprint_path|
-      destination_paths.each do |destination_path|
-        destination_path.join(path).dirname.mkpath
-        FileUtils.cp(compile_path.join(fingerprint_path), destination_path.join(path))
-      end
+      destination_path.join(path).dirname.mkpath
+      FileUtils.cp(compile_path.join(fingerprint_path), destination_path.join(path))
     end
 
     puts 'Done'

--- a/actioncable/index.coffee
+++ b/actioncable/index.coffee
@@ -1,0 +1,46 @@
+# Define ActionCable namespace and internal parameters.
+ActionCable = 
+  INTERNAL: 
+    message_types:
+      welcome: 'welcome'
+      ping: 'ping'
+      confirmation: 'confirm_subscription'
+      rejection: 'reject_subscription'
+    default_mount_path: '/cable'
+    protocols: [
+      'actioncable-v1-json'
+      'actioncable-unsupported'
+    ]
+
+# Include other modules in order.
+#= require ./app/assets/javascripts/action_cable/connection_monitor.coffee
+#= require ./app/assets/javascripts/action_cable/connection.coffee
+#= require ./app/assets/javascripts/action_cable/subscriptions.coffee
+#= require ./app/assets/javascripts/action_cable/subscription.coffee
+#= require ./app/assets/javascripts/action_cable/consumer.coffee
+
+module.exports =
+  createConsumer: (url) ->
+    new ActionCable.Consumer @createWebSocketURL(url)
+
+  createWebSocketURL: (url) ->
+    if url and not /^wss?:/i.test(url)
+      a = document.createElement("a")
+      a.href = url
+      # Fix populating Location properties in IE. Otherwise, protocol will be blank.
+      a.href = a.href
+      a.protocol = a.protocol.replace("http", "ws")
+      a.href
+    else
+      url
+
+  startDebugging: ->
+    @debugging = true
+
+  stopDebugging: ->
+    @debugging = null
+
+  log: (messages...) ->
+    if @debugging
+      messages.push(Date.now())
+      console.log("[ActionCable]", messages...)

--- a/actioncable/package.json
+++ b/actioncable/package.json
@@ -4,7 +4,7 @@
   "description": "WebSocket framework for Ruby on Rails.",
   "main": "dist/actioncable.js",
   "files": [
-    "dist/*.js"
+    "dist/actioncable.js"
   ],
   "repository": {
     "type": "git",
@@ -21,5 +21,16 @@
     "url": "https://github.com/rails/rails/issues"
   },
   "homepage": "http://rubyonrails.org/",
-  "scripts": {}
+  "scripts": {
+    "build": "./node_modules/.bin/gulp"
+  },
+  "devDependencies": {
+    "coffee-script": "^1.10.0",
+    "del": "^2.2.0",
+    "gulp": "^3.9.1",
+    "gulp-coffee": "^2.3.2",
+    "gulp-include": "^2.1.0",
+    "gulp-rename": "^1.2.2",
+    "gulp-uglify": "^1.5.3"
+  }
 }

--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -58,7 +58,7 @@ directory "pkg"
       cmd << "cd #{framework} && " unless framework == "rails"
       cmd << "bundle exec rake package && " unless framework == "rails"
       cmd << "gem build #{gemspec} && mv #{framework}-#{version}.gem #{root}/pkg/"
-      cmd << "&& npm publish" if File.exist?("#{framework}/package.json")
+      cmd << "&& npm run build && npm publish" if File.exist?("#{framework}/package.json")
       sh cmd
     end
 


### PR DESCRIPTION
* Use Gulp to build usable dist/actioncable.js
* Add index manifest for npm module, including createConsumer method
* Add npm build script and link into release scripting